### PR TITLE
fix(cli): Fixed reliance on npm as a dependency and internal npm API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,48 @@ should any of them fail.
 
 ## Usage
 
-Installation:
+**Installation:**
 
 ```
 npm install --save-dev npm-failsafe
 ```
+
+**In your project:**
+
+You should use this to run only scripts which are defined in your `package.json` file. Ideally, you should also provide all args for these scripts upfront, due to the order in which scripts/args are interpreted:
+
+Each script will be executed with `npm run`.
+
+*Best practice use case*
+
+```json
+{
+    "scripts": {
+        "test": "jest",
+        "test:coverage": "npm run test -- --coverage",
+        "lint": "eslint src/*",
+        "start": "pm2 start server.js --port=3000",
+        "ci": "failsafe start lint test:coverage"
+    }
+}
+```
+
+In the above example, you can see that args for each script on which `failsafe` will run have been provided upfront.
+
+*What is actually allowed*
+
+```bash
+# Allowed
+failsafe jest mocha webpack
+
+# Allowed
+failsafe jest mocha webpack -- --port=3000 --use-ts
+
+# Disallowed (as "mocha" and "webpack") are interpreted as additional args of "jest".
+
+failsafe jest -- --coverage mocha webpack
+```
+
 
 ## Motivation
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/jan-molak/npm-failsafe",
   "dependencies": {
-    "npm": "^2.0.0",
     "terminal-table-output": "^1.3.1"
   },
   "engines": {


### PR DESCRIPTION
Fix for use of npm which resolves poorly against older versions of npm and use of their internal npm API which isn't meant to be used externally, switching to using `child_process.exec`.

**Also modified how scripts and arguments are parsed, instituting the following rules:**

- You can pass as many "scripts" as you want as args to `failsafe`.
- When you pass args to an individual scripts you can no longer continue to pass scripts as these will be treated as args, as there is no way to delimit between one script and another after this.

All scripts are expected to be listed in the package.json file, as they will be executed with `npm run <script_name>`.

**Examples:**

```bash
# Allowed
failsafe jest mocha webpack

# Allowed
failsafe jest mocha webpack -- --port=3000 --use-ts

# Disallowed (as "mocha" and "webpack") are interpreted as additional args of "jest".

failsafe jest -- --coverage mocha webpack
```

Ideally script args should be listed along with their script definitions in package.json