### PR TITLE
Add Success/Failure message

### DIFF
--- a/spec/Failsafe.spec.ts
+++ b/spec/Failsafe.spec.ts
@@ -12,7 +12,8 @@ describe(`Failsafe`, function() {
 
     const
         Success = 0,
-        General_Failure = 1;
+        General_Failure = 1,
+        Other_Failure = 7;
 
     it(`exits with error when no scripts are specified`, async () => {
         const { run, logger } = failsafe();
@@ -54,7 +55,7 @@ describe(`Failsafe`, function() {
         { scripts: [`success`, `success`], expected_result: Success },
         { scripts: [`success`, `general-failure`], expected_result: General_Failure },
         { scripts: [`general-failure`, `general-failure`], expected_result: General_Failure },
-        { scripts: [`general`, `success`], expected_result: General_Failure },
+        { scripts: [`general-failure`, `success`], expected_result: General_Failure },
     ).
     it(`returns with the worst exit code encountered`, async ({ scripts, expected_result }) => {
         const { run, logger } = failsafe();
@@ -76,6 +77,7 @@ describe(`Failsafe`, function() {
                 '[success] Tests executed correctly',
                 '[success] Another line',
                 `[failsafe] Script 'success' exited with code 0`,
+                `[failsafe] Succeed with exit code 0 as all scripts passed`,
             ].join('\n'));
         });
 
@@ -93,6 +95,7 @@ describe(`Failsafe`, function() {
 
             expect(logger.stdout()).to.include([
                 `[failsafe] Script 'general-failure' exited with code 1`,
+                `[failsafe] Fail with exit code 1 due to failing script(s): 'general-failure'`,
             ].join('\n'));
         });
 
@@ -115,24 +118,24 @@ describe(`Failsafe`, function() {
         it(`executes scripts in a sequence`, async () => {
             const { run, logger } = failsafe();
 
-            const exitCode = await run([`success`, `general-failure`]);
+            const exitCode = await run([`general-failure`, `success`, `other-failure`]);
 
-            expect(exitCode).to.equal(General_Failure, `Expected exit code of ${General_Failure}${ format(logger) }`);
+            expect(exitCode).to.equal(Other_Failure, `Expected exit code of ${Other_Failure}${ format(logger) }`);
 
-            expect(logger.stdout()).to.include([
-                '[success] Tests executed correctly',
-                '[success] Another line',
-                `[failsafe] Script 'success' exited with code 0`,
-            ].join('\n'));
-
-            expect(logger.stderr()).to.include([
+            expect(logger.combined()).to.match(toRegex([
+                /.+/,
                 `[general-failure] A test has failed`,
                 `[general-failure] Another line describing the problem`,
-            ].join('\n'));
-
-            expect(logger.stdout()).to.include([
                 `[failsafe] Script 'general-failure' exited with code 1`,
-            ].join('\n'));
+                /.+/,
+                `[success] Tests executed correctly`,
+                `[success] Another line`,
+                `[failsafe] Script 'success' exited with code 0`,
+                /.+/,
+                `[other-failure] A script has failed`,
+                `[failsafe] Script 'other-failure' exited with code 7`,
+                `[failsafe] Fail with exit code 7 due to failing script(s): 'general-failure', 'other-failure'`,
+            ]));
         });
     });
 
@@ -491,6 +494,7 @@ ${ indented(logger.stderr()) }
 
 class AccumulatingLogger extends Logger {
     constructor(
+        public readonly allEntries: string[] = [],
         public readonly infoEntries: string[] = [],
         public readonly errorEntries: string[] = [],
     ) {
@@ -499,14 +503,23 @@ class AccumulatingLogger extends Logger {
 
     help(line: string): void {
         this.infoEntries.push(`${ line }`);
+        this.allEntries.push(`${ line }`);
     }
 
     info(scriptName: string, line: string) {
-        this.infoEntries.push(...this.prefixed(scriptName, line).split('\n'));
+        const lines = this.prefixed(scriptName, line).split('\n')
+        this.infoEntries.push(...lines);
+        this.allEntries.push(...lines);
     }
 
     error(scriptName: string, line: string) {
-        this.errorEntries.push(...this.prefixed(scriptName, line).split('\n'));
+        const lines = this.prefixed(scriptName, line).split('\n')
+        this.errorEntries.push(...lines);
+        this.allEntries.push(...lines);
+    }
+
+    combined(): string {
+        return this.allEntries.join('\n')
     }
 
     stdout(): string {
@@ -516,4 +529,21 @@ class AccumulatingLogger extends Logger {
     stderr(): string {
         return this.errorEntries.join('\n')
     }
+}
+
+function escapeRegExp(string_: string): string {
+    return string_.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+}
+
+function toRegex(lines: (string|RegExp)[]): RegExp {
+    const lastIndex = lines.length - 1;
+    return new RegExp(
+        lines.map(
+            (line, i) => (line instanceof RegExp
+                ? line.source
+                : escapeRegExp(line))
+                + (i === lastIndex ? '\n?' : '\n') // optional newline at the end
+        ).join(''),
+        'sm' // s: dot matches newline, m: multiline, ^ and $ match start/end of line
+    );
 }

--- a/spec/test-project/package.json
+++ b/spec/test-project/package.json
@@ -8,6 +8,7 @@
     "print-args": "node scripts/print-args.js",
     "also-print-args": "node scripts/print-args.js",
     "general-failure": "node scripts/ends-with-general-failure.js",
+    "other-failure": "node scripts/ends-with-other-failure.js",
     "buffered-output": "node scripts/buffered-output.js",
     "check-ansi-support": "node scripts/check-ansi-support.js"
   },

--- a/spec/test-project/scripts/ends-with-other-failure.js
+++ b/spec/test-project/scripts/ends-with-other-failure.js
@@ -1,0 +1,2 @@
+console.error('A script has failed');
+process.exit(7);

--- a/src/Failsafe.ts
+++ b/src/Failsafe.ts
@@ -2,15 +2,20 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import readline = require('readline');
 
+import { ArgumentParser, ParseError, Script, UnrecognisedArgumentsError } from './ArgumentParser';
 import { Logger, trimmed } from './logger';
 import path = require('path');
-import { ArgumentParser, ParseError, Script, UnrecognisedArgumentsError } from './ArgumentParser';
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
 
 export interface FailsafeConfig {
     cwd: string;
     isTTY: boolean;
+}
+
+export interface RunResult {
+    exitCode: ExitCode;
+    failedScripts: string[];
 }
 
 export type ExitCode = number;
@@ -82,7 +87,13 @@ export class Failsafe {
                 return 1;
             }
 
-            return await this.runScripts(scripts);
+            const result = await this.runScripts(scripts);
+            if (result.exitCode === 0) {
+                this.logger.info('failsafe', `Succeed with exit code 0 as all scripts passed`);
+            } else {
+                this.logger.info('failsafe', `Fail with exit code ${ result.exitCode } due to failing script(s): ${ result.failedScripts.map(s => `'${s}'`).join(', ') }`);
+            }
+            return result.exitCode;
         }
         catch (error: any) {
             if (error instanceof ParseError) {
@@ -112,12 +123,16 @@ export class Failsafe {
         }
     }
 
-    private async runScripts(scripts: Script[]): Promise<ExitCode> {
-        return await scripts.reduce(async (previous: Promise<ExitCode>, script: Script) => {
-            const previousExitCode = await previous;
+    private async runScripts(scripts: Script[]): Promise<RunResult> {
+        return await scripts.reduce(async (previous: Promise<RunResult>, script: Script) => {
+            const result = await previous;
             const currentExitCode = await this.runScript(script.name, script.arguments);
-            return Math.max(previousExitCode, currentExitCode);
-        }, Promise.resolve(0));
+            result.exitCode = Math.max(result.exitCode, currentExitCode);
+            if (currentExitCode !== 0) {
+                result.failedScripts.push(script.name);
+            }
+            return result;
+        }, Promise.resolve({ exitCode: 0, failedScripts: [] } as RunResult));
     }
 
     private runScript(scriptName: string, arguments_: string[] = []): Promise<ExitCode> {


### PR DESCRIPTION
Adds an additional last log line that indicates which scripts failed.

Examples
```
[failsafe] Succeed with exit code 0 as all scripts passed
```

```
[failsafe] Fail with exit code 1 due to failing script(s): 'general-failure'
```

```
[failsafe] Fail with exit code 7 due to failing script(s): 'general-failure', 'other-failure'
```